### PR TITLE
Add extensible context-menu settings MVVM scaffold

### DIFF
--- a/CommEx/App/PluginCompositionRoot.cs
+++ b/CommEx/App/PluginCompositionRoot.cs
@@ -1,7 +1,11 @@
+using System.Collections.Generic;
 using CommEx.Infrastructure.Logging;
 using CommEx.Infrastructure.Time;
 using CommEx.Services;
+using CommEx.Services.Settings;
 using CommEx.ViewModels;
+using CommEx.ViewModels.Settings;
+using CommEx.Views.Settings;
 
 namespace CommEx.App
 {
@@ -20,7 +24,20 @@ namespace CommEx.App
             IClock clock = new SystemClock();
             ITelemetryService telemetryService = new DummyTelemetryService(logger, clock);
 
-            return new MainViewModel(telemetryService, logger);
+            IPluginSettingsRepository settingsRepository = new InMemoryPluginSettingsRepository();
+            IPluginSettingsService settingsService = new PluginSettingsService(settingsRepository);
+
+            IEnumerable<ISettingsSectionViewModelFactory> factories = new ISettingsSectionViewModelFactory[]
+            {
+                new UdpSettingsSectionViewModelFactory(),
+                new ApiServerSettingsSectionViewModelFactory(),
+                new ComSettingsSectionViewModelFactory()
+            };
+
+            ContextMenuSettingsViewModel settingsViewModel = new ContextMenuSettingsViewModel(settingsService, factories);
+            IContextMenuSettingsView settingsView = new DeferredContextMenuSettingsView(logger);
+
+            return new MainViewModel(telemetryService, logger, clock, settingsView, settingsViewModel);
         }
     }
 }

--- a/CommEx/Models/Settings/ApiServerSettings.cs
+++ b/CommEx/Models/Settings/ApiServerSettings.cs
@@ -1,0 +1,18 @@
+namespace CommEx.Models.Settings
+{
+    /// <summary>
+    /// API サーバー機能の設定値を保持します。
+    /// </summary>
+    internal class ApiServerSettings
+    {
+        /// <summary>
+        /// API サーバー機能の有効状態を取得または設定します。
+        /// </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// API サーバーの待受ポート番号を取得または設定します。
+        /// </summary>
+        public int Port { get; set; } = 31000;
+    }
+}

--- a/CommEx/Models/Settings/ComPortSettings.cs
+++ b/CommEx/Models/Settings/ComPortSettings.cs
@@ -1,0 +1,58 @@
+namespace CommEx.Models.Settings
+{
+    /// <summary>
+    /// COM ポート単位の設定値です。
+    /// </summary>
+    internal class ComPortSettings
+    {
+        /// <summary>
+        /// 当該 COM ポート設定の有効状態を取得または設定します。
+        /// </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// 使用するプロトコルを取得または設定します。
+        /// </summary>
+        public ComProtocolType Protocol { get; set; } = ComProtocolType.BidsCompatible;
+
+        /// <summary>
+        /// COM ポート名を取得または設定します。
+        /// </summary>
+        public string PortName { get; set; } = "COM1";
+
+        /// <summary>
+        /// ボーレートを取得または設定します。
+        /// </summary>
+        public int BaudRate { get; set; } = 9600;
+
+        /// <summary>
+        /// データビット数を取得または設定します。
+        /// </summary>
+        public int DataBits { get; set; } = 8;
+
+        /// <summary>
+        /// ストップビット数を取得または設定します。
+        /// </summary>
+        public int StopBits { get; set; } = 1;
+
+        /// <summary>
+        /// パリティ設定値を取得または設定します。
+        /// </summary>
+        public string Parity { get; set; } = "None";
+
+        /// <summary>
+        /// DTR の有効状態を取得または設定します。
+        /// </summary>
+        public bool IsDtrEnabled { get; set; }
+
+        /// <summary>
+        /// RTS の有効状態を取得または設定します。
+        /// </summary>
+        public bool IsRtsEnabled { get; set; }
+
+        /// <summary>
+        /// 自動起動設定を取得または設定します。
+        /// </summary>
+        public bool AutoStart { get; set; }
+    }
+}

--- a/CommEx/Models/Settings/ComProtocolType.cs
+++ b/CommEx/Models/Settings/ComProtocolType.cs
@@ -1,0 +1,13 @@
+namespace CommEx.Models.Settings
+{
+    /// <summary>
+    /// COM 通信で利用するプロトコル種別です。
+    /// </summary>
+    internal enum ComProtocolType
+    {
+        BidsCompatible,
+        CommunicationDllCompatible,
+        BveSerialOutputCompatible,
+        BinaryOriginal
+    }
+}

--- a/CommEx/Models/Settings/PluginSettings.cs
+++ b/CommEx/Models/Settings/PluginSettings.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace CommEx.Models.Settings
+{
+    /// <summary>
+    /// 右クリックメニューから編集するプラグイン設定を保持します。
+    /// </summary>
+    internal class PluginSettings
+    {
+        /// <summary>
+        /// UDP 通信設定を取得または設定します。
+        /// </summary>
+        public UdpSettings Udp { get; set; } = new UdpSettings();
+
+        /// <summary>
+        /// API サーバー設定を取得または設定します。
+        /// </summary>
+        public ApiServerSettings ApiServer { get; set; } = new ApiServerSettings();
+
+        /// <summary>
+        /// COM ポート設定一覧を取得または設定します。
+        /// </summary>
+        public IList<ComPortSettings> ComPorts { get; set; } = new List<ComPortSettings>
+        {
+            new ComPortSettings()
+        };
+    }
+}

--- a/CommEx/Models/Settings/UdpNicSettings.cs
+++ b/CommEx/Models/Settings/UdpNicSettings.cs
@@ -1,0 +1,23 @@
+namespace CommEx.Models.Settings
+{
+    /// <summary>
+    /// UDP 通信における NIC ごとの設定値です。
+    /// </summary>
+    internal class UdpNicSettings
+    {
+        /// <summary>
+        /// NIC 名を取得または設定します。
+        /// </summary>
+        public string NicName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// NIC のローカル IP を取得または設定します。
+        /// </summary>
+        public string LocalIpAddress { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 送信先 IP を取得または設定します。
+        /// </summary>
+        public string DestinationIpAddress { get; set; } = string.Empty;
+    }
+}

--- a/CommEx/Models/Settings/UdpSettings.cs
+++ b/CommEx/Models/Settings/UdpSettings.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace CommEx.Models.Settings
+{
+    /// <summary>
+    /// UDP 機能の設定値を保持します。
+    /// </summary>
+    internal class UdpSettings
+    {
+        /// <summary>
+        /// UDP 機能の有効状態を取得または設定します。
+        /// </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// NIC 単位の設定一覧を取得または設定します。
+        /// </summary>
+        public IList<UdpNicSettings> Nics { get; set; } = new List<UdpNicSettings>
+        {
+            new UdpNicSettings
+            {
+                NicName = "Default",
+                LocalIpAddress = "192.168.0.10",
+                DestinationIpAddress = "192.168.0.100"
+            }
+        };
+    }
+}

--- a/CommEx/Services/Settings/IPluginSettingsRepository.cs
+++ b/CommEx/Services/Settings/IPluginSettingsRepository.cs
@@ -1,0 +1,14 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.Services.Settings
+{
+    /// <summary>
+    /// プラグイン設定の永続化境界を表します。
+    /// </summary>
+    internal interface IPluginSettingsRepository
+    {
+        PluginSettings Load();
+
+        void Save(PluginSettings settings);
+    }
+}

--- a/CommEx/Services/Settings/IPluginSettingsService.cs
+++ b/CommEx/Services/Settings/IPluginSettingsService.cs
@@ -1,0 +1,14 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.Services.Settings
+{
+    /// <summary>
+    /// 設定の読込/保存ユースケースを提供します。
+    /// </summary>
+    internal interface IPluginSettingsService
+    {
+        PluginSettings Load();
+
+        void Save(PluginSettings settings);
+    }
+}

--- a/CommEx/Services/Settings/InMemoryPluginSettingsRepository.cs
+++ b/CommEx/Services/Settings/InMemoryPluginSettingsRepository.cs
@@ -1,0 +1,23 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.Services.Settings
+{
+    /// <summary>
+    /// メモリ上に設定を保持する簡易実装です。
+    /// UI 実装前の暫定ストレージとして利用します。
+    /// </summary>
+    internal class InMemoryPluginSettingsRepository : IPluginSettingsRepository
+    {
+        private PluginSettings current = new PluginSettings();
+
+        public PluginSettings Load()
+        {
+            return current;
+        }
+
+        public void Save(PluginSettings settings)
+        {
+            current = settings;
+        }
+    }
+}

--- a/CommEx/Services/Settings/PluginSettingsService.cs
+++ b/CommEx/Services/Settings/PluginSettingsService.cs
@@ -1,0 +1,27 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.Services.Settings
+{
+    /// <summary>
+    /// 設定サービスの既定実装です。
+    /// </summary>
+    internal class PluginSettingsService : IPluginSettingsService
+    {
+        private readonly IPluginSettingsRepository repository;
+
+        public PluginSettingsService(IPluginSettingsRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public PluginSettings Load()
+        {
+            return repository.Load();
+        }
+
+        public void Save(PluginSettings settings)
+        {
+            repository.Save(settings);
+        }
+    }
+}

--- a/CommEx/ViewModels/MainViewModel.cs
+++ b/CommEx/ViewModels/MainViewModel.cs
@@ -1,7 +1,10 @@
 using System;
 using CommEx.Infrastructure.Logging;
+using CommEx.Infrastructure.Time;
 using CommEx.Models;
 using CommEx.Services;
+using CommEx.ViewModels.Settings;
+using CommEx.Views.Settings;
 
 namespace CommEx.ViewModels
 {
@@ -12,6 +15,8 @@ namespace CommEx.ViewModels
     {
         private readonly ITelemetryService telemetryService;
         private readonly IPluginLogger logger;
+        private readonly IClock clock;
+        private readonly IContextMenuSettingsView settingsView;
         private readonly PluginState state = new PluginState();
 
         /// <summary>
@@ -19,11 +24,26 @@ namespace CommEx.ViewModels
         /// </summary>
         /// <param name="telemetryService">テレメトリ通知を担当するサービス。</param>
         /// <param name="logger">ログ出力を担当するロガー。</param>
-        public MainViewModel(ITelemetryService telemetryService, IPluginLogger logger)
+        /// <param name="settingsView">右クリック設定表示を担当する View アダプタ。</param>
+        /// <param name="settingsViewModel">右クリック設定画面の ViewModel。</param>
+        public MainViewModel(
+            ITelemetryService telemetryService,
+            IPluginLogger logger,
+            IClock clock,
+            IContextMenuSettingsView settingsView,
+            ContextMenuSettingsViewModel settingsViewModel)
         {
             this.telemetryService = telemetryService;
             this.logger = logger;
+            this.clock = clock;
+            this.settingsView = settingsView;
+            SettingsViewModel = settingsViewModel;
         }
+
+        /// <summary>
+        /// 右クリック設定画面の ViewModel を取得します。
+        /// </summary>
+        public ContextMenuSettingsViewModel SettingsViewModel { get; }
 
         /// <summary>
         /// プラグインの有効状態を取得または設定します。
@@ -46,7 +66,7 @@ namespace CommEx.ViewModels
             }
 
             state.TickCount++;
-            state.LastTickUtc = DateTime.UtcNow;
+            state.LastTickUtc = clock.UtcNow;
 
             telemetryService.PublishHeartbeat(state.TickCount, elapsed);
 
@@ -54,6 +74,22 @@ namespace CommEx.ViewModels
             {
                 logger.Info("CommEx heartbeat is active.");
             }
+        }
+
+        /// <summary>
+        /// 右クリックメニューから設定表示が要求された際に呼び出します。
+        /// </summary>
+        public void OpenContextMenuSettings()
+        {
+            settingsView.Show(SettingsViewModel);
+        }
+
+        /// <summary>
+        /// 設定の保存を実行します。
+        /// </summary>
+        public void SaveSettings()
+        {
+            SettingsViewModel.Save();
         }
     }
 }

--- a/CommEx/ViewModels/Settings/ApiServerSettingsSectionViewModel.cs
+++ b/CommEx/ViewModels/Settings/ApiServerSettingsSectionViewModel.cs
@@ -1,0 +1,33 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// API サーバー設定セクションの ViewModel です。
+    /// </summary>
+    internal class ApiServerSettingsSectionViewModel : ISettingsSectionViewModel
+    {
+        private readonly ApiServerSettings settings;
+
+        public ApiServerSettingsSectionViewModel(ApiServerSettings settings)
+        {
+            this.settings = settings;
+        }
+
+        public string SectionKey => "api";
+
+        public string DisplayName => "API";
+
+        public bool IsEnabled
+        {
+            get { return settings.IsEnabled; }
+            set { settings.IsEnabled = value; }
+        }
+
+        public int Port
+        {
+            get { return settings.Port; }
+            set { settings.Port = value; }
+        }
+    }
+}

--- a/CommEx/ViewModels/Settings/ApiServerSettingsSectionViewModelFactory.cs
+++ b/CommEx/ViewModels/Settings/ApiServerSettingsSectionViewModelFactory.cs
@@ -1,0 +1,15 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// API サーバー設定セクションの ViewModel を生成します。
+    /// </summary>
+    internal class ApiServerSettingsSectionViewModelFactory : ISettingsSectionViewModelFactory
+    {
+        public ISettingsSectionViewModel Create(PluginSettings settings)
+        {
+            return new ApiServerSettingsSectionViewModel(settings.ApiServer);
+        }
+    }
+}

--- a/CommEx/ViewModels/Settings/ComSettingsSectionViewModel.cs
+++ b/CommEx/ViewModels/Settings/ComSettingsSectionViewModel.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using CommEx.Models.Settings;
+
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// COM 設定セクションの ViewModel です。
+    /// </summary>
+    internal class ComSettingsSectionViewModel : ISettingsSectionViewModel
+    {
+        private readonly IList<ComPortSettings> comPorts;
+
+        public ComSettingsSectionViewModel(IList<ComPortSettings> comPorts)
+        {
+            this.comPorts = comPorts;
+        }
+
+        public string SectionKey => "com";
+
+        public string DisplayName => "COM";
+
+        public bool IsEnabled
+        {
+            get
+            {
+                for (int i = 0; i < comPorts.Count; i++)
+                {
+                    if (comPorts[i].IsEnabled)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            set
+            {
+                for (int i = 0; i < comPorts.Count; i++)
+                {
+                    comPorts[i].IsEnabled = value;
+                }
+            }
+        }
+
+        public IList<ComPortSettings> Ports => comPorts;
+
+        public ComPortSettings AddPort()
+        {
+            ComPortSettings newPort = new ComPortSettings
+            {
+                PortName = $"COM{comPorts.Count + 1}"
+            };
+
+            comPorts.Add(newPort);
+            return newPort;
+        }
+    }
+}

--- a/CommEx/ViewModels/Settings/ComSettingsSectionViewModelFactory.cs
+++ b/CommEx/ViewModels/Settings/ComSettingsSectionViewModelFactory.cs
@@ -1,0 +1,15 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// COM 設定セクションの ViewModel を生成します。
+    /// </summary>
+    internal class ComSettingsSectionViewModelFactory : ISettingsSectionViewModelFactory
+    {
+        public ISettingsSectionViewModel Create(PluginSettings settings)
+        {
+            return new ComSettingsSectionViewModel(settings.ComPorts);
+        }
+    }
+}

--- a/CommEx/ViewModels/Settings/ContextMenuSettingsViewModel.cs
+++ b/CommEx/ViewModels/Settings/ContextMenuSettingsViewModel.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CommEx.Models.Settings;
+using CommEx.Services.Settings;
+
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// 右クリックメニューで表示する設定画面全体の ViewModel です。
+    /// </summary>
+    internal class ContextMenuSettingsViewModel
+    {
+        private readonly IPluginSettingsService settingsService;
+        private readonly PluginSettings settings;
+
+        public ContextMenuSettingsViewModel(
+            IPluginSettingsService settingsService,
+            IEnumerable<ISettingsSectionViewModelFactory> sectionFactories)
+        {
+            this.settingsService = settingsService;
+            settings = settingsService.Load();
+
+            List<ISettingsSectionViewModel> sections = new List<ISettingsSectionViewModel>();
+            foreach (ISettingsSectionViewModelFactory factory in sectionFactories)
+            {
+                sections.Add(factory.Create(settings));
+            }
+
+            Sections = new ReadOnlyCollection<ISettingsSectionViewModel>(sections);
+        }
+
+        /// <summary>
+        /// 設定セクション一覧を取得します。
+        /// </summary>
+        public IReadOnlyList<ISettingsSectionViewModel> Sections { get; }
+
+        /// <summary>
+        /// 現在の編集内容を保存します。
+        /// </summary>
+        public void Save()
+        {
+            settingsService.Save(settings);
+        }
+    }
+}

--- a/CommEx/ViewModels/Settings/ISettingsSectionViewModel.cs
+++ b/CommEx/ViewModels/Settings/ISettingsSectionViewModel.cs
@@ -1,0 +1,14 @@
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// 右クリックメニューの設定セクションを表す ViewModel 契約です。
+    /// </summary>
+    internal interface ISettingsSectionViewModel
+    {
+        string SectionKey { get; }
+
+        string DisplayName { get; }
+
+        bool IsEnabled { get; set; }
+    }
+}

--- a/CommEx/ViewModels/Settings/ISettingsSectionViewModelFactory.cs
+++ b/CommEx/ViewModels/Settings/ISettingsSectionViewModelFactory.cs
@@ -1,0 +1,12 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// 設定モデルからセクション ViewModel を生成するファクトリ契約です。
+    /// </summary>
+    internal interface ISettingsSectionViewModelFactory
+    {
+        ISettingsSectionViewModel Create(PluginSettings settings);
+    }
+}

--- a/CommEx/ViewModels/Settings/UdpSettingsSectionViewModel.cs
+++ b/CommEx/ViewModels/Settings/UdpSettingsSectionViewModel.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using CommEx.Models.Settings;
+
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// UDP 設定セクションの ViewModel です。
+    /// </summary>
+    internal class UdpSettingsSectionViewModel : ISettingsSectionViewModel
+    {
+        private readonly UdpSettings settings;
+
+        public UdpSettingsSectionViewModel(UdpSettings settings)
+        {
+            this.settings = settings;
+        }
+
+        public string SectionKey => "udp";
+
+        public string DisplayName => "UDP";
+
+        public bool IsEnabled
+        {
+            get { return settings.IsEnabled; }
+            set { settings.IsEnabled = value; }
+        }
+
+        public IList<UdpNicSettings> NicSettings => settings.Nics;
+    }
+}

--- a/CommEx/ViewModels/Settings/UdpSettingsSectionViewModelFactory.cs
+++ b/CommEx/ViewModels/Settings/UdpSettingsSectionViewModelFactory.cs
@@ -1,0 +1,15 @@
+using CommEx.Models.Settings;
+
+namespace CommEx.ViewModels.Settings
+{
+    /// <summary>
+    /// UDP 設定セクションの ViewModel を生成します。
+    /// </summary>
+    internal class UdpSettingsSectionViewModelFactory : ISettingsSectionViewModelFactory
+    {
+        public ISettingsSectionViewModel Create(PluginSettings settings)
+        {
+            return new UdpSettingsSectionViewModel(settings.Udp);
+        }
+    }
+}

--- a/CommEx/Views/Settings/DeferredContextMenuSettingsView.cs
+++ b/CommEx/Views/Settings/DeferredContextMenuSettingsView.cs
@@ -1,0 +1,23 @@
+using CommEx.Infrastructure.Logging;
+using CommEx.ViewModels.Settings;
+
+namespace CommEx.Views.Settings
+{
+    /// <summary>
+    /// UI 実装前に設定表示要求を受け取るためのプレースホルダです。
+    /// </summary>
+    internal class DeferredContextMenuSettingsView : IContextMenuSettingsView
+    {
+        private readonly IPluginLogger logger;
+
+        public DeferredContextMenuSettingsView(IPluginLogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public void Show(ContextMenuSettingsViewModel viewModel)
+        {
+            logger.Info($"Settings view requested. Sections={viewModel.Sections.Count}");
+        }
+    }
+}

--- a/CommEx/Views/Settings/IContextMenuSettingsView.cs
+++ b/CommEx/Views/Settings/IContextMenuSettingsView.cs
@@ -1,0 +1,12 @@
+using CommEx.ViewModels.Settings;
+
+namespace CommEx.Views.Settings
+{
+    /// <summary>
+    /// Bve の右クリックメニューから呼び出される設定表示のアダプタ契約です。
+    /// </summary>
+    internal interface IContextMenuSettingsView
+    {
+        void Show(ContextMenuSettingsViewModel viewModel);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -88,3 +88,10 @@ Bve起動後に右クリックメニューから設定してください。
 - `Views/`: 表示連携（現状はプレースホルダ）
 - `Services/`: 通信・I/O など副作用を持つ処理
 - `Infrastructure/`: ログ・時刻など横断的機能
+
+
+## 設定 View 実装の現状（右クリックメニュー）
+- 右クリックメニュー向け設定は `ContextMenuSettingsViewModel` で管理します。
+- 設定セクションは `ISettingsSectionViewModelFactory` で生成するため、`udp/api/com` 以外の機能もファクトリ追加で拡張できます。
+- 現在は UI 本体を未実装とし、`DeferredContextMenuSettingsView` が「表示要求を受け取るプレースホルダ」として動作します。
+- 設定モデルは `Models/Settings` 配下に集約し、`Services/Settings` から読み書きします（現在はインメモリ実装）。


### PR DESCRIPTION
### Motivation
- Provide a right-click settings UI scaffold so plugin features (UDP / API server / COM) can be configured from Bve's context menu. 
- Make settings extensible per-feature so new sections can be added without changing the core view logic. 
- Follow the repository MVVM guideline by separating Models, ViewModels, Services and a view adapter placeholder. 

### Description
- Added domain settings under `CommEx/Models/Settings` for `UdpSettings`, `ApiServerSettings`, `ComPortSettings` and related types to represent per-feature configuration. 
- Introduced settings persistence contracts and a simple in-memory repository in `CommEx/Services/Settings` plus `PluginSettingsService` as the use-case layer. 
- Implemented an extensible settings section architecture with `ISettingsSectionViewModelFactory` and concrete section ViewModels/factories for `udp`, `api`, and `com`, and the aggregate `ContextMenuSettingsViewModel`. 
- Added a view adapter contract `IContextMenuSettingsView` and a placeholder `DeferredContextMenuSettingsView`, updated `MainViewModel` to expose `OpenContextMenuSettings` and `SaveSettings` and to depend on `IClock`, and wired everything in `PluginCompositionRoot`; also documented the current state in `README.md`. 

### Testing
- Ran the solution build with `dotnet build CommEx.sln`, which completed successfully with no warnings or errors. 
- No additional automated tests were added for this scaffold in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00c21c61c8332990959e6bf4b662d)